### PR TITLE
Adding assetfinder in enum and adjusting dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,4 @@ burnrecon/settings.toml
 # Ignore dynaconf secret files
 .secrets.toml
 db
+*.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
-COPY burnrecon/ .
 
 
 

--- a/burnrecon/base.py
+++ b/burnrecon/base.py
@@ -41,5 +41,3 @@ def list_urls_from_target(target):
     query = collection.find({"target": target})
 
     return query
-
-

--- a/burnrecon/bot_discord.py
+++ b/burnrecon/bot_discord.py
@@ -7,7 +7,7 @@ from base import (
     list_subdomains,
     list_urls_from_target,
     subdomain_enum,
-    naabu_scan
+    naabu_scan,
 )
 from config import settings
 

--- a/burnrecon/subdomain_parse.py
+++ b/burnrecon/subdomain_parse.py
@@ -25,10 +25,19 @@ def exec_amass(domain):
     amass_out.unlink()
 
 
+def exec_assetfinder(domain):
+    assetfinder_out = Path(tempfile.NamedTemporaryFile(delete=False).name)
+    assetfinder_cmd = f"assetfinder -subs-only {domain} > {assetfinder_out}"
+    os.system(assetfinder_cmd)
+    os.system(f"cat {assetfinder_out} >> {final_file}")
+    assetfinder_out.unlink()
+
+
 def clean_results(domain):
     clean_subs = set()
     exec_subfinder(domain)
     exec_amass(domain)
+    exec_assetfinder(domain)
     with open(final_file, "r") as file_:
         for line in file_:
             clean_subs.add(line.rstrip("\n"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - "~/.config/subfinder:/root/.config/subfinder"
       - "~/.config/amass:/root/.config/amass"
+      - "./burnrecon:/root"
     networks:
       - backend
 


### PR DESCRIPTION
#11 
Inclui a consulta ao assetfinder e fiz uma alteração nos arquivos do docker para criar um volume no lugar de copiar os arquivos para dentro do container. Assim não é necessário refazer o build do docker para testar os novos arquivos ou atualizar os scripts no futuro.
Se achar melhor deixar como estar, é só editar o commit ou me avisar que eu excluo essas alterações e envio de novo.